### PR TITLE
Bug in insertRow and max-results parameter

### DIFF
--- a/library/ZendGData/Spreadsheets.php
+++ b/library/ZendGData/Spreadsheets.php
@@ -256,6 +256,7 @@ class Spreadsheets extends GData
         $query = new Spreadsheets\ListQuery();
         $query->setSpreadsheetKey($key);
         $query->setWorksheetId($wkshtId);
+        $query->setMaxResults(0);
 
         $feed = $this->getListFeed($query);
         $editLink = $feed->getLink('http://schemas.google.com/g/2005#post');

--- a/library/ZendGData/Spreadsheets/ListQuery.php
+++ b/library/ZendGData/Spreadsheets/ListQuery.php
@@ -228,6 +228,36 @@ class ListQuery extends \ZendGData\Query
     }
 
     /**
+     * Sets the max-results attribute for this query.
+     *
+     * @param string $value
+     * @return Zend_Gdata_Spreadsheets_ListQuery Provides a fluent interface
+     */
+    public function setMaxResults($value)
+    {
+        if ($value !== NULL) {
+            $this->_params['max-results'] = $value;
+        } else {
+            unset($this->_params['max-results']);
+        }
+        return $this;
+    }
+
+    /**
+     * Gets the max-results attribute for this query.
+     *
+     * @return string max-results
+     */
+    public function getMaxResults()
+    {
+        if (array_key_exists('max-results', $this->_params)) {
+            return $this->_params['max-results'];
+        } else {
+            return null;
+        }
+    }
+ 
+    /**
      * Gets the full query URL for this query.
      * @return string url
      */


### PR DESCRIPTION
While working with Spreadsheets list feed, insertRow method loads the whole feed for selected worksheet to get the edit URL. When a worksheet has a lot of records this may take a while and even lead to a crash. That's where max-results parameter comes in handy. It limits the number of rows returned by list feed query. It can also be zero so it returns only a header of the list feed.
